### PR TITLE
Customizable Go Versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,4 @@ LABEL maintainer="Jay Zhang <wangyoucao577@gmail.com>"
 
 
 
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,3 @@ COPY *.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 
 LABEL maintainer="Jay Zhang <wangyoucao577@gmail.com>"
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ jobs:
 - Release for multiple OS/ARCH in parallel by matrix strategy.    
 - `Go` code is not in `.` of your repository.    
 - Customize binary name.    
+- Use `go 1.13.1` from downloadable URL instead of default `1.14`.
 
 ```yaml
 # .github/workflows/release.yaml
@@ -75,6 +76,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
+        goversion: "https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz"
         project_path: "./cmd/test-binary"
         binary_name: "test-binary"
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Automatically publish `Go` binaries to Github Release Assets through Github Acti
 
 ## Features    
 - Build `Go` binaries for release and publish to Github Release Assets.     
-- Uses `golang 1.14`.    
+- Customizable `Go` versions. `golang 1.14` by default.    
 - Support different `Go` project path in repository.     
 - Support multiple binaries in same repository.    
 - Customizable binary name.     
@@ -17,7 +17,6 @@ Automatically publish `Go` binaries to Github Release Assets through Github Acti
 
 ```yaml
 # .github/workflows/release.yaml
-name: Release Go Binaries
 
 on: 
   release:
@@ -43,6 +42,7 @@ jobs:
 | github_token | **Mandatory** | Your `GITHUB_TOKEN` for uploading releases to Github asserts. |
 | goos | **Mandatory** | `GOOS` is the running program's operating system target: one of `darwin`, `freebsd`, `linux`, and so on. |
 | goarch | **Mandatory** | `GOARCH` is the running program's architecture target: one of `386`, `amd64`, `arm`, `s390x`, and so on. |
+| goversion |  **Optional** | The `Go` compiler version. `1.14` by default, optional `1.13`. <br>It also takes download URL instead of version string if you'd like to use more specified version. But make sure your URL is `linux-amd64` package, better to find the URL from [Go - Downloads](https://golang.org/dl/).<br>E.g., `https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz`. |
 | project_path | **Optional** | Where to run `go build`. <br>Use `.` by default. |
 | binary_name | **Optional** | Specify another binary name if do not want to use repository basename. <br>Use your repository's basename if not set. |
 
@@ -54,16 +54,10 @@ jobs:
 
 ```yaml
 # .github/workflows/release.yaml
-name: Release Go Binaries
 
 on: 
   release:
     types: [created]
-
-env:
-  GO_PROJECT_PATH: ./cmd/test-binary
-  BINARY_NAME: test-binary
-
 
 jobs:
   releases-matrix:
@@ -81,7 +75,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
-        project_path: "${{ env.GO_PROJECT_PATH }}"
-        binary_name: "${{ env.BINARY_NAME }}"
+        project_path: "./cmd/test-binary"
+        binary_name: "test-binary"
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'GOARCH is the running programs architecture target: one of 386, amd64, arm, s390x, and so on.'
     required: true
     default: ''
+  goversion:
+    description: 'The `Go` compiler version.'
+    required: false
+    default: ''
   project_path:
     description: 'Where to run `go build .`'
     required: false
@@ -30,6 +34,7 @@ runs:
     - ${{ inputs.github_token }}
     - ${{ inputs.goos }}
     - ${{ inputs.goarch }}
+    - ${{ inputs.goversion }}
     - ${{ inputs.project_path }}
     - ${{ inputs.binary_name }}
     - ${{ inputs.compression }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 # prepare golang
 source /setup-go.sh 
-
+go version
 
 # prepare binary/release name
 BINARY_NAME=$(basename ${GITHUB_REPOSITORY})

--- a/setup-go.sh
+++ b/setup-go.sh
@@ -1,7 +1,14 @@
 #!/bin/bash -eux
 
-wget --progress=dot:mega https://dl.google.com/go/go1.14.linux-amd64.tar.gz -O go-linux-amd64.tar.gz 
-tar -zxf go-linux-amd64.tar.gz
+GO_LINUX_PACKAGE_URL="https://dl.google.com/go/go1.14.linux-amd64.tar.gz"
+if [ ${INPUT_GOVERSION} == "1.13" ]; then
+    GO_LINUX_PACKAGE_URL="https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz"
+elif [[ ${INPUT_GOVERSION} == "http*" ]]; then
+    GO_LINUX_PACKAGE_URL=${INPUT_GOVERSION}
+fi
+
+wget --progress=dot:mega ${GO_LINUX_PACKAGE_URL} -O go-linux.tar.gz 
+tar -zxf go-linux.tar.gz
 mv go /usr/local/
 mkdir -p /go/bin /go/src /go/pkg
 

--- a/setup-go.sh
+++ b/setup-go.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eux
 
 GO_LINUX_PACKAGE_URL="https://dl.google.com/go/go1.14.linux-amd64.tar.gz"
-if [ ${INPUT_GOVERSION} == "1.13" ]; then
+if [[ ${INPUT_GOVERSION} == "1.13" ]]; then
     GO_LINUX_PACKAGE_URL="https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz"
 elif [[ ${INPUT_GOVERSION} == "http*" ]]; then
     GO_LINUX_PACKAGE_URL=${INPUT_GOVERSION}

--- a/setup-go.sh
+++ b/setup-go.sh
@@ -3,7 +3,7 @@
 GO_LINUX_PACKAGE_URL="https://dl.google.com/go/go1.14.linux-amd64.tar.gz"
 if [[ ${INPUT_GOVERSION} == "1.13" ]]; then
     GO_LINUX_PACKAGE_URL="https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz"
-elif [[ ${INPUT_GOVERSION} == "http*" ]]; then
+elif [[ ${INPUT_GOVERSION} == http* ]]; then
     GO_LINUX_PACKAGE_URL=${INPUT_GOVERSION}
 fi
 


### PR DESCRIPTION
New parameter `goversion` can take `1.14`, `1.13` or downloadable `linux/amd64` URL(e.g., `https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz`). 