### PR TITLE
Support publish to specific release on every `push` event

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteract
   && rm -rf /var/lib/apt/lists/*
 
 # github-assets-uploader to provide robust github assets upload
-RUN wget --no-check-certificate --progress=dot:mega https://github.com/wangyoucao577/assets-uploader/releases/download/v0.1.1/github-assets-uploader-v0.1.1-linux-amd64.tar.gz -O github-assets-uploader.tar.gz && \
+RUN wget --no-check-certificate --progress=dot:mega https://github.com/wangyoucao577/assets-uploader/releases/download/v0.1.2/github-assets-uploader-v0.1.2-linux-amd64.tar.gz -O github-assets-uploader.tar.gz && \
   tar -zxf github-assets-uploader.tar.gz && \
   mv github-assets-uploader /usr/sbin/ && \
   rm -f github-assets-uploader.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteract
   zip \
   jq
 
+# github-assets-uploader to provide robust github assets upload
+RUN wget --progress=dot:mega https://github.com/wangyoucao577/assets-uploader/releases/download/v0.1.0/github-assets-uploader-v0.1.0-linux-amd64.tar.gz -O github-assets-uploader.tar.gz && \
+  tar -zxf github-assets-uploader.tar.gz && \
+  mv github-assets-uploader /usr/sbin/ && \
+  rm -f github-assets-uploader.tar.gz && \
+  github-assets-uploader -version
 
 COPY *.sh /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteract
   && rm -rf /var/lib/apt/lists/*
 
 # github-assets-uploader to provide robust github assets upload
-RUN wget --no-check-certificate --progress=dot:mega https://github.com/wangyoucao577/assets-uploader/releases/download/v0.1.3/github-assets-uploader-v0.1.3-linux-amd64.tar.gz -O github-assets-uploader.tar.gz && \
+RUN wget --no-check-certificate --progress=dot:mega https://github.com/wangyoucao577/assets-uploader/releases/download/v0.2.0/github-assets-uploader-v0.2.0-linux-amd64.tar.gz -O github-assets-uploader.tar.gz && \
   tar -zxf github-assets-uploader.tar.gz && \
   mv github-assets-uploader /usr/sbin/ && \
   rm -f github-assets-uploader.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteract
   && rm -rf /var/lib/apt/lists/*
 
 # github-assets-uploader to provide robust github assets upload
-RUN wget --no-check-certificate --progress=dot:mega https://github.com/wangyoucao577/assets-uploader/releases/download/v0.1.2/github-assets-uploader-v0.1.2-linux-amd64.tar.gz -O github-assets-uploader.tar.gz && \
+RUN wget --no-check-certificate --progress=dot:mega https://github.com/wangyoucao577/assets-uploader/releases/download/v0.1.3/github-assets-uploader-v0.1.3-linux-amd64.tar.gz -O github-assets-uploader.tar.gz && \
   tar -zxf github-assets-uploader.tar.gz && \
   mv github-assets-uploader /usr/sbin/ && \
   rm -f github-assets-uploader.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
 
 FROM debian:stretch-slim
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   curl \
   wget \
   git \
   build-essential \
   zip \
-  jq
+  jq \
+  && rm -rf /var/lib/apt/lists/*
 
 # github-assets-uploader to provide robust github assets upload
-RUN wget --progress=dot:mega https://github.com/wangyoucao577/assets-uploader/releases/download/v0.1.0/github-assets-uploader-v0.1.0-linux-amd64.tar.gz -O github-assets-uploader.tar.gz && \
+RUN wget --progress=dot:mega https://github.com/wangyoucao577/assets-uploader/releases/download/v0.1.1/github-assets-uploader-v0.1.1-linux-amd64.tar.gz -O github-assets-uploader.tar.gz && \
   tar -zxf github-assets-uploader.tar.gz && \
   mv github-assets-uploader /usr/sbin/ && \
   rm -f github-assets-uploader.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,11 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteract
   build-essential \
   zip \
   jq \
+  ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
 # github-assets-uploader to provide robust github assets upload
-RUN wget --progress=dot:mega https://github.com/wangyoucao577/assets-uploader/releases/download/v0.1.1/github-assets-uploader-v0.1.1-linux-amd64.tar.gz -O github-assets-uploader.tar.gz && \
+RUN wget --no-check-certificate --progress=dot:mega https://github.com/wangyoucao577/assets-uploader/releases/download/v0.1.1/github-assets-uploader-v0.1.1-linux-amd64.tar.gz -O github-assets-uploader.tar.gz && \
   tar -zxf github-assets-uploader.tar.gz && \
   mv github-assets-uploader /usr/sbin/ && \
   rm -f github-assets-uploader.tar.gz && \

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Automatically publish `Go` binaries to Github Release Assets through Github Acti
 - Support customize build command, e.g., use [packr2](https://github.com/gobuffalo/packr/tree/master/v2)(`packr2 build`) instead of `go build`.     
 - Support optional `.md5` along with artifacts.     
 - Customizable release tag to support publish binaries per `push`.      
+- Support overwrite assets if it's already exist.    
 
 ## Usage
 
@@ -59,6 +60,7 @@ jobs:
 | extra_files | **Optional** | Extra files that will be packaged into artifacts either. Multiple files separated by space. Note that extra folders can be allowed either since internal `cp -r` already in use. <br>E.g., `extra_files: LICENSE README.md` |
 | md5sum | **Optional** | Publish `.md5` along with artifacts, `TRUE` by default. |
 | release_tag | **Optional** | Target release tag to publish your binaries to. It's dedicated to publish binaries on every `push` into one specified release page since there's no target in this case. DON'T set it if you trigger the action by `release: [created]` event as most people do.|
+| overwrite | **Optional** | Overwrite asset if it's alreaddy exist.|
 
 ### Advanced Example
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ jobs:
 | md5sum | **Optional** | Publish `.md5` along with artifacts, `TRUE` by default. |
 | sha256sum | **Optional** | Publish `.sha256` along with artifacts, `FALSE` by default. |
 | release_tag | **Optional** | Target release tag to publish your binaries to. It's dedicated to publish binaries on every `push` into one specified release page since there's no target in this case. DON'T set it if you trigger the action by `release: [created]` event as most people do.|
-| overwrite | **Optional** | Overwrite asset if it's alreaddy exist.|
+| overwrite | **Optional** | Overwrite asset if it's already exist. `FALSE` by default. |
 
 ### Advanced Example
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Automatically publish `Go` binaries to Github Release Assets through Github Acti
 - Support package extra files into artifacts (e.g., `LICENSE`, `README.md`, etc).    
 - Support customize build command, e.g., use [packr2](https://github.com/gobuffalo/packr/tree/master/v2)(`packr2 build`) instead of `go build`.     
 - Support optional `.md5` along with artifacts.     
+- Customizable release tag to support publish binaries per `push`.      
 
 ## Usage
 
@@ -57,7 +58,7 @@ jobs:
 | ldflags | **Optional** | Values to provide to the `-ldflags` argument. |
 | extra_files | **Optional** | Extra files that will be packaged into artifacts either. Multiple files separated by space. Note that extra folders can be allowed either since internal `cp -r` already in use. <br>E.g., `extra_files: LICENSE README.md` |
 | md5sum | **Optional** | Publish `.md5` along with artifacts, `TRUE` by default. |
-
+| release_tag | **Optional** | Target release tag to publish your binaries to. It's dedicated to publish binaries on every `push` into one specified release page since there's no target in this case. DON'T set it if you trigger the action by `release: [created]` event as most people do.|
 
 ### Advanced Example
 

--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ inputs:
     required: false
     default: ''
   overwrite:
-    description: 'Overwrite asset if it's already exist.'
+    description: "Overwrite asset if it's already exist."
     required: false
     default: 'FALSE'
 

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,10 @@ inputs:
     description: 'Publish `.md5` along with artifacts.'
     required: false
     default: 'TRUE'
+  release_tag:
+    description: 'Upload binaries to specified release page that indicated by Git tag.'
+    required: false
+    default: ''
 
 runs:
   using: 'docker'
@@ -68,6 +72,7 @@ runs:
     - ${{ inputs.build_command }}
     - ${{ inputs.extra_files }}
     - ${{ inputs.md5sum }}
+    - ${{ inputs.release_tag }}
 
 branding:
   icon: 'package'  

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,10 @@ inputs:
     description: 'Upload binaries to specified release page that indicated by Git tag.'
     required: false
     default: ''
+  overwrite:
+    description: 'Overwrite asset if it's already exist.'
+    required: false
+    default: 'FALSE'
 
 runs:
   using: 'docker'
@@ -73,6 +77,7 @@ runs:
     - ${{ inputs.extra_files }}
     - ${{ inputs.md5sum }}
     - ${{ inputs.release_tag }}
+    - ${{ inputs.overwrite }}
 
 branding:
   icon: 'package'  

--- a/release.sh
+++ b/release.sh
@@ -69,16 +69,12 @@ tar cvfz ${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT} *
 fi
 MD5_SUM=$(md5sum ${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT} | cut -d ' ' -f 1)
 
-# update binary and checksum
-github-assets-uploader -f ${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT} -repo ${GITHUB_REPOSITORY} -token ${INPUT_GITHUB_TOKEN} -mediatype ${MEDIA_TYPE} -tag ${RELEASE_TAG}
+MD5_EXT='.md5'
+MD5_MEDIA_TYPE='text/plain'
+echo ${MD5_SUM} >${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}${MD5_EXT}
 
+# update binary and checksum
+github-assets-uploader -f ${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT} -mediatype ${MEDIA_TYPE} -repo ${GITHUB_REPOSITORY} -token ${INPUT_GITHUB_TOKEN} -tag ${RELEASE_TAG}
 if [ ${INPUT_MD5SUM^^} == 'TRUE' ]; then
-curl \
-  --fail \
-  -X POST \
-  --data ${MD5_SUM} \
-  -H 'Content-Type: text/plain' \
-  -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" \
-  "${RELEASE_ASSETS_UPLOAD_URL}?name=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}.md5"
-echo $?
+github-assets-uploader -f ${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}${MD5_EXT} -mediatype ${MD5_MEDIA_TYPE} -repo ${GITHUB_REPOSITORY} -token ${INPUT_GITHUB_TOKEN} -tag ${RELEASE_TAG}
 fi

--- a/release.sh
+++ b/release.sh
@@ -5,11 +5,22 @@ BINARY_NAME=$(basename ${GITHUB_REPOSITORY})
 if [ x${INPUT_BINARY_NAME} != x ]; then
   BINARY_NAME=${INPUT_BINARY_NAME}
 fi
-RELEASE_TAG=$(basename ${GITHUB_REF})
+if [ ! -z "${INPUT_RELEASE_TAG}" ]; then
+    RELEASE_TAG=${INPUT_RELEASE_TAG}
+else
+    # have to triggered by 'release: [create]' event, so that we can parse the tag from ref
+    RELEASE_TAG=$(basename ${GITHUB_REF})
+fi
 RELEASE_ASSET_NAME=${BINARY_NAME}-${RELEASE_TAG}-${INPUT_GOOS}-${INPUT_GOARCH}
 
 # prepare upload URL
-RELEASE_ASSETS_UPLOAD_URL=$(cat ${GITHUB_EVENT_PATH} | jq -r .release.upload_url)
+if [ ${GITHUB_EVENT_NAME} == 'release' ]; then
+    # only for 'release: [created]' event, we can parse event directly to get upload_url
+    RELEASE_ASSETS_UPLOAD_URL=$(cat ${GITHUB_EVENT_PATH} | jq -r .release.upload_url)
+else
+    # otherwise we have to get upload url via Github API, e.g., triggerred by 'push' event that no upload url info 
+    RELEASE_ASSETS_UPLOAD_URL=$(curl "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" | jq -r .upload_url) 
+fi
 RELEASE_ASSETS_UPLOAD_URL=${RELEASE_ASSETS_UPLOAD_URL%\{?name,label\}}
 
 # execute pre-command if exist, e.g. `go get -v ./...`

--- a/release.sh
+++ b/release.sh
@@ -13,7 +13,9 @@ RELEASE_ASSET_NAME=${BINARY_NAME}-${RELEASE_TAG}-${INPUT_GOOS}-${INPUT_GOARCH}
 
 # prompt error if non-supported event
 if [ ${GITHUB_EVENT_NAME} == 'release' ]; then
+    echo "Event: ${GITHUB_EVENT_NAME}"
 elif [ ${GITHUB_EVENT_NAME} == 'push' ]; then
+    echo "Event: ${GITHUB_EVENT_NAME}"
 else
     echo "Unsupport event: ${GITHUB_EVENT_NAME}!"
     exit 1

--- a/release.sh
+++ b/release.sh
@@ -59,8 +59,10 @@ ls -lha
 
 # compress and package binary, then calculate checksum
 RELEASE_ASSET_EXT='.tar.gz'
+MEDIA_TYPE='application/gzip'
 if [ ${INPUT_GOOS} == 'windows' ]; then
 RELEASE_ASSET_EXT='.zip'
+MEDIA_TYPE='application/zip'
 zip -vr ${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT} *
 else
 tar cvfz ${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT} *
@@ -68,14 +70,7 @@ fi
 MD5_SUM=$(md5sum ${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT} | cut -d ' ' -f 1)
 
 # update binary and checksum
-curl \
-  --fail \
-  -X POST \
-  --data-binary @${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT} \
-  -H 'Content-Type: application/gzip' \
-  -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" \
-  "${RELEASE_ASSETS_UPLOAD_URL}?name=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}"
-echo $?
+github-assets-uploader -f ${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT} -repo ${GITHUB_REPOSITORY} -token ${INPUT_GITHUB_TOKEN} -mediatype ${MEDIA_TYPE} -tag ${RELEASE_TAG}
 
 if [ ${INPUT_MD5SUM^^} == 'TRUE' ]; then
 curl \

--- a/release.sh
+++ b/release.sh
@@ -5,22 +5,18 @@ BINARY_NAME=$(basename ${GITHUB_REPOSITORY})
 if [ x${INPUT_BINARY_NAME} != x ]; then
   BINARY_NAME=${INPUT_BINARY_NAME}
 fi
-if [ ! -z "${INPUT_RELEASE_TAG}" ]; then
-    RELEASE_TAG=${INPUT_RELEASE_TAG}
-else
-    # have to triggered by 'release: [create]' event, so that we can parse the tag from ref
-    RELEASE_TAG=$(basename ${GITHUB_REF})
-fi 
 
 # prepare upload URL and asset name
 if [ ${GITHUB_EVENT_NAME} == 'release' ]; then
     # only for 'release: [created]' event, we can parse event directly to get upload_url
     RELEASE_ASSETS_UPLOAD_URL=$(cat ${GITHUB_EVENT_PATH} | jq -r .release.upload_url)
+    RELEASE_TAG=$(basename ${GITHUB_REF})
     RELEASE_ASSET_NAME=${BINARY_NAME}-${RELEASE_TAG}-${INPUT_GOOS}-${INPUT_GOARCH}
 else
-    # otherwise we have to get upload url via Github API, e.g., triggerred by 'push' event that no upload url info 
-    RELEASE_ASSETS_UPLOAD_URL=$(curl "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" | jq -r .upload_url) 
-    RELEASE_ASSET_NAME=${BINARY_NAME}-${RELEASE_TAG}-${GITHUB_SHA::7}-${INPUT_GOOS}-${INPUT_GOARCH}
+    # otherwise we have to get upload url via Github API, e.g., triggerred by 'push' event that no upload url info. 'INPUT_RELEASE_TAG' has to be set in this case. 
+    RELEASE_ASSETS_UPLOAD_URL=$(curl "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/tags/${INPUT_RELEASE_TAG}" | jq -r .upload_url) 
+    BRANCH_NAME=$(basename ${GITHUB_REF})
+    RELEASE_ASSET_NAME=${BINARY_NAME}-${BRANCH_NAME}-$(date -u +%Y%m%d)-${GITHUB_SHA::7}-${INPUT_GOOS}-${INPUT_GOARCH}
 fi
 RELEASE_ASSETS_UPLOAD_URL=${RELEASE_ASSETS_UPLOAD_URL%\{?name,label\}}
 

--- a/release.sh
+++ b/release.sh
@@ -12,11 +12,14 @@ if [ ${GITHUB_EVENT_NAME} == 'release' ]; then
     RELEASE_ASSETS_UPLOAD_URL=$(cat ${GITHUB_EVENT_PATH} | jq -r .release.upload_url)
     RELEASE_TAG=$(basename ${GITHUB_REF})
     RELEASE_ASSET_NAME=${BINARY_NAME}-${RELEASE_TAG}-${INPUT_GOOS}-${INPUT_GOARCH}
-else
+elif [ ${GITHUB_EVENT_NAME} == 'push' ]; then
     # otherwise we have to get upload url via Github API, e.g., triggerred by 'push' event that no upload url info. 'INPUT_RELEASE_TAG' has to be set in this case. 
     RELEASE_ASSETS_UPLOAD_URL=$(curl "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/tags/${INPUT_RELEASE_TAG}" | jq -r .upload_url) 
     BRANCH_NAME=$(basename ${GITHUB_REF})
     RELEASE_ASSET_NAME=${BINARY_NAME}-${BRANCH_NAME}-$(date -u +%Y%m%d)-${GITHUB_SHA::7}-${INPUT_GOOS}-${INPUT_GOARCH}
+else
+    echo "Unsupport event: ${GITHUB_EVENT_NAME}!"
+    exit 1
 fi
 RELEASE_ASSETS_UPLOAD_URL=${RELEASE_ASSETS_UPLOAD_URL%\{?name,label\}}
 

--- a/release.sh
+++ b/release.sh
@@ -67,10 +67,6 @@ fi
 MD5_SUM=$(md5sum ${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT} | cut -d ' ' -f 1)
 SHA256_SUM=$(sha256sum ${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT} | cut -d ' ' -f 1)
 
-MD5_EXT='.md5'
-MD5_MEDIA_TYPE='text/plain'
-echo ${MD5_SUM} >${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}${MD5_EXT}
-
 # prefix upload extra params 
 GITHUB_ASSETS_UPLOADR_EXTRA_OPTIONS=''
 if [ ${INPUT_OVERWRITE^^} == 'TRUE' ]; then
@@ -80,16 +76,15 @@ fi
 # update binary and checksum
 github-assets-uploader -f ${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT} -mediatype ${MEDIA_TYPE} ${GITHUB_ASSETS_UPLOADR_EXTRA_OPTIONS} -repo ${GITHUB_REPOSITORY} -token ${INPUT_GITHUB_TOKEN} -tag ${RELEASE_TAG}
 if [ ${INPUT_MD5SUM^^} == 'TRUE' ]; then
+MD5_EXT='.md5'
+MD5_MEDIA_TYPE='text/plain'
+echo ${MD5_SUM} >${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}${MD5_EXT}
 github-assets-uploader -f ${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}${MD5_EXT} -mediatype ${MD5_MEDIA_TYPE} ${GITHUB_ASSETS_UPLOADR_EXTRA_OPTIONS} -repo ${GITHUB_REPOSITORY} -token ${INPUT_GITHUB_TOKEN} -tag ${RELEASE_TAG}
 fi
 
 if [ ${INPUT_SHA256SUM^^} == 'TRUE' ]; then
-curl \
-  --fail \
-  --X POST \
-  --data ${SHA256_SUM} \
-  -H 'Content-Type: text/plain' \
-  -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" \
-  "${RELEASE_ASSETS_UPLOAD_URL}?name=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}.sha256"
-echo $?
+SHA256_EXT='.sha256'
+SHA256_MEDIA_TYPE='text/plain'
+echo ${SHA256_SUM} >${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}${SHA256_EXT}
+github-assets-uploader -f ${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}${SHA256_EXT} -mediatype ${SHA256_MEDIA_TYPE} ${GITHUB_ASSETS_UPLOADR_EXTRA_OPTIONS} -repo ${GITHUB_REPOSITORY} -token ${INPUT_GITHUB_TOKEN} -tag ${RELEASE_TAG}
 fi

--- a/release.sh
+++ b/release.sh
@@ -10,16 +10,17 @@ if [ ! -z "${INPUT_RELEASE_TAG}" ]; then
 else
     # have to triggered by 'release: [create]' event, so that we can parse the tag from ref
     RELEASE_TAG=$(basename ${GITHUB_REF})
-fi
-RELEASE_ASSET_NAME=${BINARY_NAME}-${RELEASE_TAG}-${INPUT_GOOS}-${INPUT_GOARCH}
+fi 
 
-# prepare upload URL
+# prepare upload URL and asset name
 if [ ${GITHUB_EVENT_NAME} == 'release' ]; then
     # only for 'release: [created]' event, we can parse event directly to get upload_url
     RELEASE_ASSETS_UPLOAD_URL=$(cat ${GITHUB_EVENT_PATH} | jq -r .release.upload_url)
+    RELEASE_ASSET_NAME=${BINARY_NAME}-${RELEASE_TAG}-${INPUT_GOOS}-${INPUT_GOARCH}
 else
     # otherwise we have to get upload url via Github API, e.g., triggerred by 'push' event that no upload url info 
-    RELEASE_ASSETS_UPLOAD_URL=$(curl "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" | jq -r .upload_url) 
+    RELEASE_ASSETS_UPLOAD_URL=$(curl "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" | jq -r .upload_url) 
+    RELEASE_ASSET_NAME=${BINARY_NAME}-${RELEASE_TAG}-${GITHUB_SHA::7}-${INPUT_GOOS}-${INPUT_GOARCH}
 fi
 RELEASE_ASSETS_UPLOAD_URL=${RELEASE_ASSETS_UPLOAD_URL%\{?name,label\}}
 

--- a/release.sh
+++ b/release.sh
@@ -70,7 +70,7 @@ echo ${MD5_SUM} >${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}${MD5_EXT}
 
 # prefix upload extra params 
 GITHUB_ASSETS_UPLOADR_EXTRA_OPTIONS=''
-if [ ! -z "${INPUT_OVERWRITE}" ]; then
+if [ ${INPUT_OVERWRITE^^} == 'TRUE' ]; then
     GITHUB_ASSETS_UPLOADR_EXTRA_OPTIONS="-overwrite"
 fi
 


### PR DESCRIPTION
This feature has been asked several times by different peoples, so that I just try to bring it in. Be aware that it still looks a little bit strange since the published stuff more like **artifacts** instead of **release assets**.     

### Changes:    
- Allow to set a specific `release_tag` as permanent publish target to support publish per `push`;     
- Integrate `github-assets-uploader` to able to `overwrite` if asset exists;     
- Remove `apt` rubbish to reduce docker size;     
