### PR TITLE
Prepare prebuilt images

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -25,7 +25,7 @@ jobs:
       uses: managedkaos/print-env@v1.0
     - name: Append latest if master branches # env '${IMAGE_TAG},latest'
       if: endsWith(github.ref, 'master')
-      run: echo IMAGE_TAG=${IMAGE_TAG},latest >> ${GITHUB_ENV}
+      run: echo IMAGE_TAG=${IMAGE_TAG},master,latest >> ${GITHUB_ENV}
     - name: Environment Printer
       uses: managedkaos/print-env@v1.0
 

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -2,10 +2,8 @@ name: Build Docker
 
 on: 
   push:
-    branches:
-    - '**'
-    paths-ignore:
-    - '*.md'
+    branches-ignore:
+    - '*-prebuilt'
 
 jobs:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: Release Action Docker
 on: 
   push:
     tags:
-    - '**'
+    - 'v**'
+    - '!*-prebuilt' # don't want to build docker image for 'prebuilt' suffix tag
 
 jobs:
 


### PR DESCRIPTION

- Publish docker image with `master` tag when from `master` branch
- Ignore docker build for `-prebuilt` suffix branch/tag