### PR TITLE
Test the go-release-action itself

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -75,3 +75,4 @@ jobs:
         goversion: https://golang.org/dl/go1.16.2.linux-amd64.tar.gz
         project_path: ./test/
         binary_name: testcmd
+        pre_command: go mod init localtest

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Run go-release-action on test code
       uses: ./
       with:
-        github_token: "FAKE-TOKEN"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
         goversion: https://golang.org/dl/go1.16.2.linux-amd64.tar.gz

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -56,3 +56,18 @@ jobs:
         snapshot: false
         tags: "${{ env.IMAGE_TAG }}"
 
+  basic-test:
+    name: Basic Acceptance Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, windows, darwin]
+        goarch: [amd64]
+    steps:
+    - uses: ./
+        github_token: "FAKE-TOKEN"
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}
+        goversion: https://golang.org/dl/go1.16.2.linux-amd64.tar.gz
+        project_path: ./test/
+        binary_name: testcmd

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         goos: [linux, windows, darwin]
-        goarch: [amd64]
+        goarch: [amd64, "386"]
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -76,6 +76,7 @@ jobs:
         project_path: ./test/
         binary_name: testmain
         pre_command: go mod init localtest
+        build_flags: -v
         md5sum: false
         sha256sum: true
         overwrite: true

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -55,3 +55,4 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
         snapshot: false
         tags: "${{ env.IMAGE_TAG }}"
+

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -57,7 +57,7 @@ jobs:
         tags: "${{ env.IMAGE_TAG }}"
 
   basic-test:
-    name: Basic Acceptance Test
+    name: Acceptance Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -74,5 +74,10 @@ jobs:
         goarch: ${{ matrix.goarch }}
         goversion: https://golang.org/dl/go1.16.2.linux-amd64.tar.gz
         project_path: ./test/
-        binary_name: testcmd
+        binary_name: testmain
         pre_command: go mod init localtest
+        md5sum: false
+        sha256sum: true
+        overwrite: true
+        release_tag: v0.1-test-assets
+        asset_name: testmain-${{ matrix.goos }}-${{ matrix.goarch }}

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -64,6 +64,8 @@ jobs:
         goos: [linux, windows, darwin]
         goarch: [amd64]
     steps:
+    - name: Checkout
+      uses: actions/checkout@v2
     - name: Run go-release-action on test code
       uses: ./
       with:

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -55,30 +55,3 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
         snapshot: false
         tags: "${{ env.IMAGE_TAG }}"
-
-  basic-test:
-    name: Acceptance Test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        goos: [linux, windows, darwin]
-        goarch: [amd64, "386"]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Run go-release-action on test code
-      uses: ./
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        goos: ${{ matrix.goos }}
-        goarch: ${{ matrix.goarch }}
-        goversion: https://golang.org/dl/go1.16.2.linux-amd64.tar.gz
-        project_path: ./test/
-        binary_name: testmain
-        pre_command: go mod init localtest
-        build_flags: -v
-        md5sum: false
-        sha256sum: true
-        overwrite: true
-        release_tag: v0.1-test-assets
-        asset_name: testmain-${{ matrix.goos }}-${{ matrix.goarch }}

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -64,7 +64,9 @@ jobs:
         goos: [linux, windows, darwin]
         goarch: [amd64]
     steps:
-    - uses: ./
+    - name: Run go-release-action on test code
+      uses: ./
+      with:
         github_token: "FAKE-TOKEN"
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}

--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -37,6 +37,35 @@ jobs:
         sha256sum: true
         overwrite: true
         release_tag: v0.1-test-assets
-        asset_name: testmain-${{ matrix.goos }}-${{ matrix.goarch }}
+        asset_name: testmain-acceptance-${{ matrix.goos }}-${{ matrix.goarch }}
 
-      
+  setup-go-test:
+    name: Set up Go Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux]
+        goarch: [amd64]
+        # "" means default
+        goversion: ["", "1.13", "https://golang.org/dl/go1.16.2.linux-amd64.tar.gz"]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set GO_VERSION_TAG env
+      run: echo GO_VERSION_TAG=$(basename ${{ matrix.goversion }}) >> ${GITHUB_ENV}
+    - name: Run go-release-action on test code
+      uses: ./
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}
+        goversion: ${{ matrix.goversion }}
+        project_path: ./test/
+        binary_name: testmain
+        pre_command: go mod init localtest
+        build_flags: -v
+        ldflags: -X "main.buildTime=${{ env.BUILD_TIME }}" -X main.gitCommit=${{ github.sha }} -X main.gitRef=${{ github.ref }}
+        md5sum: false
+        overwrite: true
+        release_tag: v0.1-test-assets
+        asset_name: testmain-set-up-go-${{ env.GO_VERSION_TAG }}-${{ matrix.goos }}-${{ matrix.goarch }}

--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -1,0 +1,39 @@
+name: Test 
+
+on: 
+  push:
+    branches-ignore:
+    - '*-prebuilt'
+
+jobs:
+  acceptance-test:
+    name: Acceptance Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, windows, darwin]
+        goarch: [amd64, "386"]
+        exclude:  
+          - goarch: "386"
+            goos: darwin 
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Run go-release-action on test code
+      uses: ./
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}
+        goversion: https://golang.org/dl/go1.16.2.linux-amd64.tar.gz
+        project_path: ./test/
+        binary_name: testmain
+        pre_command: go mod init localtest
+        build_flags: -v
+        md5sum: false
+        sha256sum: true
+        overwrite: true
+        release_tag: v0.1-test-assets
+        asset_name: testmain-${{ matrix.goos }}-${{ matrix.goarch }}
+
+      

--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+    - name: Set BUILD_TIME env
+      run: echo BUILD_TIME=$(date) >> ${GITHUB_ENV}
     - name: Run go-release-action on test code
       uses: ./
       with:
@@ -30,6 +32,7 @@ jobs:
         binary_name: testmain
         pre_command: go mod init localtest
         build_flags: -v
+        ldflags: -X "main.buildTime=${{ env.BUILD_TIME }}" -X main.gitCommit=${{ github.sha }} -X main.gitRef=${{ github.ref }}
         md5sum: false
         sha256sum: true
         overwrite: true

--- a/test/test_main.go
+++ b/test/test_main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello Action!")
+}

--- a/test/test_main.go
+++ b/test/test_main.go
@@ -2,6 +2,22 @@ package main
 
 import "fmt"
 
+const notSet string = "not set"
+
+// these information will be collected when build, by `-ldflags "-X main.gitCommit=06b8d24"`
+var (
+	buildTime = notSet
+	gitCommit = notSet
+	gitRef    = notSet
+)
+
+func printVersion() {
+	fmt.Printf("Build Time: %s\n", buildTime)
+	fmt.Printf("Git Commit: %s\n", gitCommit)
+	fmt.Printf("Git Ref:    %s\n", gitRef)
+}
+
 func main() {
 	fmt.Println("Hello Action!")
+	printVersion()
 }


### PR DESCRIPTION
- Support to test most of commands;       
- Support to test set up different versions of go; 
- Triggerred by `push`.     