### PR TITLE
Upgrade Go

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -47,7 +47,7 @@ jobs:
         goos: [linux]
         goarch: [amd64]
         # "" means default
-        goversion: ["", "1.13", "https://golang.org/dl/go1.16.2.linux-amd64.tar.gz"]
+        goversion: ["", "1.13", "1.14", "1.15", "https://golang.org/dl/go1.16.1.linux-amd64.tar.gz"]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Automatically publish `Go` binaries to Github Release Assets through Github Acti
 
 ## Features    
 - Build `Go` binaries for release and publish to Github Release Assets.     
-- Customizable `Go` versions. `golang 1.14` by default.    
+- Customizable `Go` versions. `golang 1.16` by default.    
 - Support different `Go` project path in repository.     
 - Support multiple binaries in same repository.    
 - Customizable binary name.     
@@ -53,7 +53,7 @@ jobs:
 | github_token | **Mandatory** | Your `GITHUB_TOKEN` for uploading releases to Github asserts. |
 | goos | **Mandatory** | `GOOS` is the running program's operating system target: one of `darwin`, `freebsd`, `linux`, and so on. |
 | goarch | **Mandatory** | `GOARCH` is the running program's architecture target: one of `386`, `amd64`, `arm`, `s390x`, and so on. |
-| goversion |  **Optional** | The `Go` compiler version. `1.14` by default, optional `1.13`. <br>It also takes download URL instead of version string if you'd like to use more specified version. But make sure your URL is `linux-amd64` package, better to find the URL from [Go - Downloads](https://golang.org/dl/).<br>E.g., `https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz`. |
+| goversion |  **Optional** | The `Go` compiler version. `1.16` by default, optional `1.13`, `1.14` or `1.15`. <br>It also takes download URL instead of version string if you'd like to use more specified version. But make sure your URL is `linux-amd64` package, better to find the URL from [Go - Downloads](https://golang.org/dl/).<br>E.g., `https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz`. |
 | project_path | **Optional** | Where to run `go build`. <br>Use `.` by default. |
 | binary_name | **Optional** | Specify another binary name if do not want to use repository basename. <br>Use your repository's basename if not set. |
 | pre_command | **Optional** | Extra command that will be executed before `go build`. You may want to use it to solve dependency if you're NOT using [Go Modules](https://github.com/golang/go/wiki/Modules). |
@@ -72,7 +72,7 @@ jobs:
 - Release for multiple OS/ARCH in parallel by matrix strategy.    
 - `Go` code is not in `.` of your repository.    
 - Customize binary name.    
-- Use `go 1.13.1` from downloadable URL instead of default `1.14`.
+- Use `go 1.13.1` from downloadable URL instead of default `1.16`.
 - Package extra `LICENSE` and `README.md` into artifacts.    
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -88,9 +88,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # build and publish in parallel: linux/386, linux/amd64, windows/386, windows/amd64, darwin/386, darwin/amd64 
+        # build and publish in parallel: linux/386, linux/amd64, windows/386, windows/amd64, darwin/amd64 
         goos: [linux, windows, darwin]
         goarch: ["386", amd64]
+        exclude:  
+          - goarch: "386"
+            goos: darwin 
     steps:
     - uses: actions/checkout@v2
     - uses: wangyoucao577/go-release-action@v1.15

--- a/setup-go.sh
+++ b/setup-go.sh
@@ -1,7 +1,11 @@
 #!/bin/bash -eux
 
-GO_LINUX_PACKAGE_URL="https://dl.google.com/go/go1.14.linux-amd64.tar.gz"
-if [[ ${INPUT_GOVERSION} == "1.13" ]]; then
+GO_LINUX_PACKAGE_URL="https://golang.org/dl/go1.16.2.linux-amd64.tar.gz"
+if [[ ${INPUT_GOVERSION} == "1.15" ]]; then
+    GO_LINUX_PACKAGE_URL="https://golang.org/dl/go1.15.10.linux-amd64.tar.gz"
+elif [[ ${INPUT_GOVERSION} == "1.14" ]]; then
+    GO_LINUX_PACKAGE_URL="https://golang.org/dl/go1.14.15.linux-amd64.tar.gz"
+elif [[ ${INPUT_GOVERSION} == "1.13" ]]; then
     GO_LINUX_PACKAGE_URL="https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz"
 elif [[ ${INPUT_GOVERSION} == http* ]]; then
     GO_LINUX_PACKAGE_URL=${INPUT_GOVERSION}


### PR DESCRIPTION
- Upgrade default go version to `1.16`;     
- Support more shortcuts: `1.14`, `1.15`.     