### PR TITLE
Upgrade Go versions

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -53,7 +53,7 @@ jobs:
         goos: [linux]
         goarch: [amd64]
         # "" means default
-        goversion: ["", "1.13", "1.14", "1.15", "https://golang.org/dl/go1.16.1.linux-amd64.tar.gz"]
+        goversion: ["", "1.13", "1.14", "1.15", "1.16", "1.17", "https://golang.org/dl/go1.16.1.linux-amd64.tar.gz"]
     steps:
     # - name: Wait release docker build for release branches
     #  if: contains(github.ref, 'release')

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Automatically publish `Go` binaries to Github Release Assets through Github Acti
 
 ## Features    
 - Build `Go` binaries for release and publish to Github Release Assets.     
-- Customizable `Go` versions. `golang 1.16` by default.    
+- Customizable `Go` versions. `latest` by default.    
 - Support different `Go` project path in repository.     
 - Support multiple binaries in same repository.    
 - Customizable binary name.     
@@ -54,7 +54,7 @@ jobs:
 | github_token | **Mandatory** | Your `GITHUB_TOKEN` for uploading releases to Github asserts. |
 | goos | **Mandatory** | `GOOS` is the running program's operating system target: one of `darwin`, `freebsd`, `linux`, and so on. |
 | goarch | **Mandatory** | `GOARCH` is the running program's architecture target: one of `386`, `amd64`, `arm`, `s390x`, and so on. |
-| goversion |  **Optional** | The `Go` compiler version. `1.16` by default, optional `1.13`, `1.14` or `1.15`. <br>It also takes download URL instead of version string if you'd like to use more specified version. But make sure your URL is `linux-amd64` package, better to find the URL from [Go - Downloads](https://golang.org/dl/).<br>E.g., `https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz`. |
+| goversion |  **Optional** | The `Go` compiler version. `latest`([check it here](https://golang.org/VERSION?m=text)) by default, optional `1.13`, `1.14`, `1.15`, `1.16` or `1.17`. <br>It also takes download URL instead of version string if you'd like to use more specified version. But make sure your URL is `linux-amd64` package, better to find the URL from [Go - Downloads](https://golang.org/dl/).<br>E.g., `https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz`. |
 | project_path | **Optional** | Where to run `go build`. <br>Use `.` by default. |
 | binary_name | **Optional** | Specify another binary name if do not want to use repository basename. <br>Use your repository's basename if not set. |
 | pre_command | **Optional** | Extra command that will be executed before `go build`. You may want to use it to solve dependency if you're NOT using [Go Modules](https://github.com/golang/go/wiki/Modules). |
@@ -74,7 +74,7 @@ jobs:
 - Release for multiple OS/ARCH in parallel by matrix strategy.    
 - `Go` code is not in `.` of your repository.    
 - Customize binary name.    
-- Use `go 1.13.1` from downloadable URL instead of default `1.16`.
+- Use `go 1.13.1` from downloadable URL instead of the default version.
 - Package extra `LICENSE` and `README.md` into artifacts.    
 
 ```yaml

--- a/setup-go.sh
+++ b/setup-go.sh
@@ -1,7 +1,9 @@
 #!/bin/bash -eux
 
-GO_LINUX_PACKAGE_URL="https://golang.org/dl/go1.17.linux-amd64.tar.gz"
-if [[ ${INPUT_GOVERSION} == "1.16" ]]; then
+GO_LINUX_PACKAGE_URL="https://dl.google.com/go/$(curl https://golang.org/VERSION?m=text).linux-amd64.tar.gz"
+if [[ ${INPUT_GOVERSION} == "1.17" ]]; then
+    GO_LINUX_PACKAGE_URL="https://golang.org/dl/go1.17.linux-amd64.tar.gz"
+elif [[ ${INPUT_GOVERSION} == "1.16" ]]; then
     GO_LINUX_PACKAGE_URL="https://golang.org/dl/go1.16.7.linux-amd64.tar.gz"
 elif [[ ${INPUT_GOVERSION} == "1.15" ]]; then
     GO_LINUX_PACKAGE_URL="https://golang.org/dl/go1.15.10.linux-amd64.tar.gz"

--- a/setup-go.sh
+++ b/setup-go.sh
@@ -1,8 +1,7 @@
 #!/bin/bash -eux
 
 GO_LINUX_PACKAGE_URL="https://golang.org/dl/go1.17.linux-amd64.tar.gz"
-if [[ ${INPUT_GOVERSION} == "1.17" ]]; then
-elif [[ ${INPUT_GOVERSION} == "1.16" ]]; then
+if [[ ${INPUT_GOVERSION} == "1.16" ]]; then
     GO_LINUX_PACKAGE_URL="https://golang.org/dl/go1.16.7.linux-amd64.tar.gz"
 elif [[ ${INPUT_GOVERSION} == "1.15" ]]; then
     GO_LINUX_PACKAGE_URL="https://golang.org/dl/go1.15.10.linux-amd64.tar.gz"

--- a/setup-go.sh
+++ b/setup-go.sh
@@ -1,7 +1,10 @@
 #!/bin/bash -eux
 
-GO_LINUX_PACKAGE_URL="https://golang.org/dl/go1.16.2.linux-amd64.tar.gz"
-if [[ ${INPUT_GOVERSION} == "1.15" ]]; then
+GO_LINUX_PACKAGE_URL="https://golang.org/dl/go1.17.linux-amd64.tar.gz"
+if [[ ${INPUT_GOVERSION} == "1.17" ]]; then
+elif [[ ${INPUT_GOVERSION} == "1.16" ]]; then
+    GO_LINUX_PACKAGE_URL="https://golang.org/dl/go1.16.7.linux-amd64.tar.gz"
+elif [[ ${INPUT_GOVERSION} == "1.15" ]]; then
     GO_LINUX_PACKAGE_URL="https://golang.org/dl/go1.15.10.linux-amd64.tar.gz"
 elif [[ ${INPUT_GOVERSION} == "1.14" ]]; then
     GO_LINUX_PACKAGE_URL="https://golang.org/dl/go1.14.15.linux-amd64.tar.gz"


### PR DESCRIPTION
- Always use [latest](https://golang.org/VERSION?m=text) by default;   
- Support `1.16` and `1.17` fields.   