### PR TITLE
ISSUE-66: Change golang.org to go.dev

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -34,7 +34,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
-        goversion: https://golang.org/dl/go1.16.2.linux-amd64.tar.gz
+        goversion: https://go.dev/dl/go1.16.2.linux-amd64.tar.gz
         project_path: ./test/
         binary_name: testmain
         pre_command: go mod init localtest
@@ -100,7 +100,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
-        goversion: https://golang.org/dl/go1.16.6.linux-amd64.tar.gz
+        goversion: https://go.dev/dl/go1.16.6.linux-amd64.tar.gz
         project_path: ./test/
         binary_name: testmain
         pre_command: go mod init localtest

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ jobs:
 | github_token | **Mandatory** | Your `GITHUB_TOKEN` for uploading releases to Github asserts. |
 | goos | **Mandatory** | `GOOS` is the running program's operating system target: one of `darwin`, `freebsd`, `linux`, and so on. |
 | goarch | **Mandatory** | `GOARCH` is the running program's architecture target: one of `386`, `amd64`, `arm`, `arm64`, `s390x`, and so on. |
-| goversion |  **Optional** | The `Go` compiler version. `latest`([check it here](https://golang.org/VERSION?m=text)) by default, optional `1.13`, `1.14`, `1.15`, `1.16` or `1.17`. <br>It also takes download URL instead of version string if you'd like to use more specified version. But make sure your URL is `linux-amd64` package, better to find the URL from [Go - Downloads](https://golang.org/dl/).<br>E.g., `https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz`. |
+| goversion |  **Optional** | The `Go` compiler version. `latest`([check it here](https://go.dev/VERSION?m=text)) by default, optional `1.13`, `1.14`, `1.15`, `1.16` or `1.17`. <br>It also takes download URL instead of version string if you'd like to use more specified version. But make sure your URL is `linux-amd64` package, better to find the URL from [Go - Downloads](https://go.dev/dl/).<br>E.g., `https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz`. |
 | project_path | **Optional** | Where to run `go build`. <br>Use `.` by default. |
 | binary_name | **Optional** | Specify another binary name if do not want to use repository basename. <br>Use your repository's basename if not set. |
 | pre_command | **Optional** | Extra command that will be executed before `go build`. You may want to use it to solve dependency if you're NOT using [Go Modules](https://github.com/golang/go/wiki/Modules). |

--- a/setup-go.sh
+++ b/setup-go.sh
@@ -1,14 +1,14 @@
 #!/bin/bash -eux
 
-GO_LINUX_PACKAGE_URL="https://dl.google.com/go/$(curl https://golang.org/VERSION?m=text).linux-amd64.tar.gz"
+GO_LINUX_PACKAGE_URL="https://dl.google.com/go/$(curl https://go.dev/VERSION?m=text).linux-amd64.tar.gz"
 if [[ ${INPUT_GOVERSION} == "1.17" ]]; then
-    GO_LINUX_PACKAGE_URL="https://golang.org/dl/go1.17.linux-amd64.tar.gz"
+    GO_LINUX_PACKAGE_URL="https://go.dev/dl/go1.17.linux-amd64.tar.gz"
 elif [[ ${INPUT_GOVERSION} == "1.16" ]]; then
-    GO_LINUX_PACKAGE_URL="https://golang.org/dl/go1.16.7.linux-amd64.tar.gz"
+    GO_LINUX_PACKAGE_URL="https://go.dev/dl/go1.16.7.linux-amd64.tar.gz"
 elif [[ ${INPUT_GOVERSION} == "1.15" ]]; then
-    GO_LINUX_PACKAGE_URL="https://golang.org/dl/go1.15.10.linux-amd64.tar.gz"
+    GO_LINUX_PACKAGE_URL="https://go.dev/dl/go1.15.10.linux-amd64.tar.gz"
 elif [[ ${INPUT_GOVERSION} == "1.14" ]]; then
-    GO_LINUX_PACKAGE_URL="https://golang.org/dl/go1.14.15.linux-amd64.tar.gz"
+    GO_LINUX_PACKAGE_URL="https://go.dev/dl/go1.14.15.linux-amd64.tar.gz"
 elif [[ ${INPUT_GOVERSION} == "1.13" ]]; then
     GO_LINUX_PACKAGE_URL="https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz"
 elif [[ ${INPUT_GOVERSION} == http* ]]; then


### PR DESCRIPTION
This should fix https://github.com/wangyoucao577/go-release-action/issues/66