### PR TITLE
Correct typo, 'assets' instead of 'asserts'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ jobs:
 
 | Parameter | **Mandatory**/**Optional** | Description |
 | --------- | -------- | ----------- |
-| github_token | **Mandatory** | Your `GITHUB_TOKEN` for uploading releases to Github asserts. |
+| github_token | **Mandatory** | Your `GITHUB_TOKEN` for uploading releases to Github assets. |
 | goos | **Mandatory** | `GOOS` is the running program's operating system target: one of `darwin`, `freebsd`, `linux`, and so on. |
 | goarch | **Mandatory** | `GOARCH` is the running program's architecture target: one of `386`, `amd64`, `arm`, `arm64`, `s390x`, and so on. |
 | goversion |  **Optional** | The `Go` compiler version. `latest`([check it here](https://go.dev/VERSION?m=text)) by default, optional `1.13`, `1.14`, `1.15`, `1.16` or `1.17`. <br>It also takes download URL instead of version string if you'd like to use more specified version. But make sure your URL is `linux-amd64` package, better to find the URL from [Go - Downloads](https://go.dev/dl/).<br>E.g., `https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz`. |


### PR DESCRIPTION
Correcting the typo in the documentation, 'assets' instead of 'asserts'.