### PR TITLE
Add support to produce zip files for all platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ jobs:
 | asset_name | **Optional** | Customize asset name if do not want to use the default format `${BINARY_NAME}-${RELEASE_TAG}-${GOOS}-${GOARCH}`. <br>Make sure set it correctly, especially for matrix usage that you have to append `-${{ matrix.goos }}-${{ matrix.goarch }}`. A valid example could be  `asset_name: binary-name-${{ matrix.goos }}-${{ matrix.goarch }}`. |
 | retry | **Optional** | How many times retrying if upload fails. `3` by default. |
 | post_command | **Optional** | Extra command that will be executed for teardown work. e.g. you can use it to upload artifacts to AWS s3 or aliyun OSS |
-| compress_assets | **Optional** | Upload execuable binaries rather than `.tar.gz` or `.zip` package. |
+| compress_assets | **Optional** | `auto` default will produce a `zip` file for Windows and `tar.gz` for others. `zip` will force the use of of `zip`. `OFF` will disable packaging of assets. |
 
 ### Advanced Example
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ jobs:
 | asset_name | **Optional** | Customize asset name if do not want to use the default format `${BINARY_NAME}-${RELEASE_TAG}-${GOOS}-${GOARCH}`. <br>Make sure set it correctly, especially for matrix usage that you have to append `-${{ matrix.goos }}-${{ matrix.goarch }}`. A valid example could be  `asset_name: binary-name-${{ matrix.goos }}-${{ matrix.goarch }}`. |
 | retry | **Optional** | How many times retrying if upload fails. `3` by default. |
 | post_command | **Optional** | Extra command that will be executed for teardown work. e.g. you can use it to upload artifacts to AWS s3 or aliyun OSS |
-| compress_assets | **Optional** | Upload executable binaries rather than `.tar.gz` or `.zip` package. |
-| compress_assets_format | **Optional** |  Values of `zip` or `gz` will produce executable binaries in the specified format . `""` default. By default linux binaries will be `gz` format and windows binaries will be `zip`|
+| compress_assets | **Optional** | Upload execuable binaries rather than `.tar.gz` or `.zip` package. |
+| zip_assets | **Optional** | Upload executable binaries published in a `.zip` package. `FALSE` by default. |
 
 ### Advanced Example
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ jobs:
 | retry | **Optional** | How many times retrying if upload fails. `3` by default. |
 | post_command | **Optional** | Extra command that will be executed for teardown work. e.g. you can use it to upload artifacts to AWS s3 or aliyun OSS |
 | compress_assets | **Optional** | Upload execuable binaries rather than `.tar.gz` or `.zip` package. |
+| zip_assets | **Optional** | Upload executable binaries published in a `.zip` package. `FALSE` by default. |
 
 ### Advanced Example
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ jobs:
 | asset_name | **Optional** | Customize asset name if do not want to use the default format `${BINARY_NAME}-${RELEASE_TAG}-${GOOS}-${GOARCH}`. <br>Make sure set it correctly, especially for matrix usage that you have to append `-${{ matrix.goos }}-${{ matrix.goarch }}`. A valid example could be  `asset_name: binary-name-${{ matrix.goos }}-${{ matrix.goarch }}`. |
 | retry | **Optional** | How many times retrying if upload fails. `3` by default. |
 | post_command | **Optional** | Extra command that will be executed for teardown work. e.g. you can use it to upload artifacts to AWS s3 or aliyun OSS |
-| compress_assets | **Optional** | Upload execuable binaries rather than `.tar.gz` or `.zip` package. |
-| zip_assets | **Optional** | Upload executable binaries published in a `.zip` package. `FALSE` by default. |
+| compress_assets | **Optional** | Upload executable binaries rather than `.tar.gz` or `.zip` package. |
+| compress_assets_format | **Optional** |  Values of `zip` or `gz` will produce executable binaries in the specified format . `""` default. By default linux binaries will be `gz` format and windows binaries will be `zip`|
 
 ### Advanced Example
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ jobs:
 | retry | **Optional** | How many times retrying if upload fails. `3` by default. |
 | post_command | **Optional** | Extra command that will be executed for teardown work. e.g. you can use it to upload artifacts to AWS s3 or aliyun OSS |
 | compress_assets | **Optional** | Upload execuable binaries rather than `.tar.gz` or `.zip` package. |
-| zip_assets | **Optional** | Upload executable binaries published in a `.zip` package. `FALSE` by default. |
 
 ### Advanced Example
 

--- a/action.yml
+++ b/action.yml
@@ -91,6 +91,10 @@ inputs:
     description: 'Compress assets before uploading'
     required: false
     default: 'TRUE'
+  zip_assets:
+    description: 'Produce zip file assets for all platforms'
+    required: false
+    default: 'FALSE'
 
 runs:
   using: 'docker'
@@ -117,6 +121,7 @@ runs:
     - ${{ inputs.retry }}
     - ${{ inputs.post_command }}
     - ${{ inputs.compress_assets }}
+    - ${{ inputs.zip_assets }}
 
 branding:
   icon: 'package'

--- a/action.yml
+++ b/action.yml
@@ -91,10 +91,10 @@ inputs:
     description: 'Compress assets before uploading'
     required: false
     default: 'TRUE'
-  compress_assets_format:
-    description: 'Defines compression method for compressed assets'
+  zip_assets:
+    description: 'Produce zip file assets for all platforms'
     required: false
-    default: ''
+    default: 'FALSE'
 
 runs:
   using: 'docker'
@@ -121,6 +121,7 @@ runs:
     - ${{ inputs.retry }}
     - ${{ inputs.post_command }}
     - ${{ inputs.compress_assets }}
+    - ${{ inputs.zip_assets }}
 
 branding:
   icon: 'package'

--- a/action.yml
+++ b/action.yml
@@ -91,10 +91,10 @@ inputs:
     description: 'Compress assets before uploading'
     required: false
     default: 'TRUE'
-  zip_assets:
-    description: 'Produce zip file assets for all platforms'
+  compress_assets_format:
+    description: 'Defines compression method for compressed assets'
     required: false
-    default: 'FALSE'
+    default: ''
 
 runs:
   using: 'docker'
@@ -121,7 +121,6 @@ runs:
     - ${{ inputs.retry }}
     - ${{ inputs.post_command }}
     - ${{ inputs.compress_assets }}
-    - ${{ inputs.zip_assets }}
 
 branding:
   icon: 'package'

--- a/action.yml
+++ b/action.yml
@@ -91,10 +91,6 @@ inputs:
     description: 'Compress assets before uploading'
     required: false
     default: 'TRUE'
-  zip_assets:
-    description: 'Produce zip file assets for all platforms'
-    required: false
-    default: 'FALSE'
 
 runs:
   using: 'docker'
@@ -121,7 +117,6 @@ runs:
     - ${{ inputs.retry }}
     - ${{ inputs.post_command }}
     - ${{ inputs.compress_assets }}
-    - ${{ inputs.zip_assets }}
 
 branding:
   icon: 'package'

--- a/release.sh
+++ b/release.sh
@@ -106,16 +106,17 @@ ls -lha
 
 if [ ${INPUT_COMPRESS_ASSETS^^} == 'TRUE' ]; then
   # compress and package binary, then calculate checksum
-  RELEASE_ASSET_EXT='.tar.gz'
-  MEDIA_TYPE='application/gzip'
-  RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}
-  if [ ${INPUT_GOOS} == 'windows' || ${INPUT_ZIP_ASSETS} == 'TRUE' ]; then
+  if [ ${INPUT_GOOS} != 'windows' || ${INPUT_COMPRESS_ASSETS_FORMAT} == 'gz' ]; then
+    RELEASE_ASSET_EXT='.tar.gz'
+    MEDIA_TYPE='application/gzip'
+    RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}
+    ( shopt -s dotglob; tar cvfz ${RELEASE_ASSET_FILE} * )
+  fi
+  if [ ${INPUT_GOOS} == 'windows' || ${INPUT_COMPRESS_ASSETS_FORMAT} == 'zip' ]; then
     RELEASE_ASSET_EXT='.zip'
     MEDIA_TYPE='application/zip'
     RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}
     ( shopt -s dotglob; zip -vr ${RELEASE_ASSET_FILE} * )
-  else
-    ( shopt -s dotglob; tar cvfz ${RELEASE_ASSET_FILE} * )
   fi
 else
   RELEASE_ASSET_EXT=${EXT}

--- a/release.sh
+++ b/release.sh
@@ -109,7 +109,7 @@ if [ ${INPUT_COMPRESS_ASSETS^^} == 'TRUE' ]; then
   RELEASE_ASSET_EXT='.tar.gz'
   MEDIA_TYPE='application/gzip'
   RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}
-  if [ ${INPUT_GOOS} == 'windows' || ${INPUT_ZIP_ASSETS} == 'TRUE' ]; then
+  if [ ${INPUT_GOOS} == 'windows' ]; then
     RELEASE_ASSET_EXT='.zip'
     MEDIA_TYPE='application/zip'
     RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}

--- a/release.sh
+++ b/release.sh
@@ -104,12 +104,13 @@ fi
 cd ${BUILD_ARTIFACTS_FOLDER}
 ls -lha
 
-if [ ${INPUT_COMPRESS_ASSETS^^} == 'TRUE' ]; then
+# INPUT_COMPRESS_ASSETS=='TRUE' is used for backwards compatability. `AUTO`, `ZIP`, `OFF` are the recommended values
+if [ ${INPUT_COMPRESS_ASSETS^^} == "TRUE" ] || [ ${INPUT_COMPRESS_ASSETS^^} == "AUTO" ] || [ ${INPUT_COMPRESS_ASSETS^^} == "ZIP" ]; then
   # compress and package binary, then calculate checksum
   RELEASE_ASSET_EXT='.tar.gz'
   MEDIA_TYPE='application/gzip'
   RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}
-  if [ ${INPUT_GOOS} == 'windows' ]; then
+  if [ ${INPUT_GOOS} == 'windows' ] || [ ${INPUT_COMPRESS_ASSETS^^} == "ZIP" ]; then
     RELEASE_ASSET_EXT='.zip'
     MEDIA_TYPE='application/zip'
     RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}
@@ -117,11 +118,14 @@ if [ ${INPUT_COMPRESS_ASSETS^^} == 'TRUE' ]; then
   else
     ( shopt -s dotglob; tar cvfz ${RELEASE_ASSET_FILE} * )
   fi
-else
+elif [ ${INPUT_COMPRESS_ASSETS^^} == "OFF" ]; then
   RELEASE_ASSET_EXT=${EXT}
   MEDIA_TYPE="application/octet-stream"
   RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}
   cp ${BINARY_NAME}${EXT} ${RELEASE_ASSET_FILE}
+else
+  echo "Invalid value for INPUT_COMPRESS_ASSETS: ${INPUT_COMPRESS_ASSETS} . Acceptable values are AUTO,ZIP, or OFF."
+  exit 1
 fi
 MD5_SUM=$(md5sum ${RELEASE_ASSET_FILE} | cut -d ' ' -f 1)
 SHA256_SUM=$(sha256sum ${RELEASE_ASSET_FILE} | cut -d ' ' -f 1)

--- a/release.sh
+++ b/release.sh
@@ -106,17 +106,16 @@ ls -lha
 
 if [ ${INPUT_COMPRESS_ASSETS^^} == 'TRUE' ]; then
   # compress and package binary, then calculate checksum
-  if [ ${INPUT_GOOS} != 'windows' || ${INPUT_COMPRESS_ASSETS_FORMAT} == 'gz' ]; then
-    RELEASE_ASSET_EXT='.tar.gz'
-    MEDIA_TYPE='application/gzip'
-    RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}
-    ( shopt -s dotglob; tar cvfz ${RELEASE_ASSET_FILE} * )
-  fi
-  if [ ${INPUT_GOOS} == 'windows' || ${INPUT_COMPRESS_ASSETS_FORMAT} == 'zip' ]; then
+  RELEASE_ASSET_EXT='.tar.gz'
+  MEDIA_TYPE='application/gzip'
+  RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}
+  if [ ${INPUT_GOOS} == 'windows' || ${INPUT_ZIP_ASSETS} == 'TRUE' ]; then
     RELEASE_ASSET_EXT='.zip'
     MEDIA_TYPE='application/zip'
     RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}
     ( shopt -s dotglob; zip -vr ${RELEASE_ASSET_FILE} * )
+  else
+    ( shopt -s dotglob; tar cvfz ${RELEASE_ASSET_FILE} * )
   fi
 else
   RELEASE_ASSET_EXT=${EXT}

--- a/release.sh
+++ b/release.sh
@@ -109,7 +109,7 @@ if [ ${INPUT_COMPRESS_ASSETS^^} == 'TRUE' ]; then
   RELEASE_ASSET_EXT='.tar.gz'
   MEDIA_TYPE='application/gzip'
   RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}
-  if [ ${INPUT_GOOS} == 'windows' ]; then
+  if [ ${INPUT_GOOS} == 'windows' || ${INPUT_ZIP_ASSETS} == 'TRUE' ]; then
     RELEASE_ASSET_EXT='.zip'
     MEDIA_TYPE='application/zip'
     RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}


### PR DESCRIPTION
My use case might be an edge use case. I've written a AWS lambda in go and AWS expects the binary in a zip file format. This PR adds a flag `zip_assets` which when true will produce zip files for both windows and Linux OS. Previous to this change only windows builds would produce a zip file, all others would get a tar.gz