### PR TITLE
Fix compress_assets for compatibility

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -75,7 +75,7 @@ jobs:
         goos: [linux]
         goarch: [amd64]
         # "" means default
-        goversion: ["", "1.13", "1.14", "1.15", "1.16", "1.17", "1.18", "https://golang.org/dl/go1.16.1.linux-amd64.tar.gz"]
+        goversion: ["", "1.17", "1.18", "1.19", "https://golang.org/dl/go1.16.1.linux-amd64.tar.gz"]
     steps:
     # - name: Wait release docker build for release branches
     #  if: contains(github.ref, 'release')
@@ -130,13 +130,14 @@ jobs:
         release_tag: v0.1-test-assets
         asset_name: testmain-via-makefile-${{ matrix.goos }}-${{ matrix.goarch }}
 
-  compress-assets-off-test:
+  compress-assets-test:
     name: Compress assets off Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
         goos: [linux, windows, darwin]
         goarch: [amd64]
+        compress_assets: ['auto', 'true', 'zip', 'off', 'false']
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -152,4 +153,4 @@ jobs:
         build_flags: -v
         overwrite: true
         release_tag: v0.1-test-assets
-        compress_assets: false
+        compress_assets: ${{ matrix.compress_assets }}

--- a/release.sh
+++ b/release.sh
@@ -118,7 +118,7 @@ if [ ${INPUT_COMPRESS_ASSETS^^} == "TRUE" ] || [ ${INPUT_COMPRESS_ASSETS^^} == "
   else
     ( shopt -s dotglob; tar cvfz ${RELEASE_ASSET_FILE} * )
   fi
-elif [ ${INPUT_COMPRESS_ASSETS^^} == "OFF" ] || [ ${INPUT_COMPRESS_ASSETS^^} == "FALSE" ];; then
+elif [ ${INPUT_COMPRESS_ASSETS^^} == "OFF" ] || [ ${INPUT_COMPRESS_ASSETS^^} == "FALSE" ]; then
   RELEASE_ASSET_EXT=${EXT}
   MEDIA_TYPE="application/octet-stream"
   RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}

--- a/release.sh
+++ b/release.sh
@@ -118,7 +118,7 @@ if [ ${INPUT_COMPRESS_ASSETS^^} == "TRUE" ] || [ ${INPUT_COMPRESS_ASSETS^^} == "
   else
     ( shopt -s dotglob; tar cvfz ${RELEASE_ASSET_FILE} * )
   fi
-elif [ ${INPUT_COMPRESS_ASSETS^^} == "OFF" ]; then
+elif [ ${INPUT_COMPRESS_ASSETS^^} == "OFF" ] || [ ${INPUT_COMPRESS_ASSETS^^} == "FALSE" ];; then
   RELEASE_ASSET_EXT=${EXT}
   MEDIA_TYPE="application/octet-stream"
   RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}


### PR DESCRIPTION
- Allow `false` for `compress_assets`;      
- Test combinations of `compress_assets`;      
- Remove too many go version test;     