### PR TITLE
Add Support for External Release Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ jobs:
 | sha256sum | **Optional** | Publish `.sha256` along with artifacts, `FALSE` by default. |
 | release_tag | **Optional** | Target release tag to publish your binaries to. It's dedicated to publish binaries on every `push` into one specified release page since there's no target in this case. DON'T set it if you trigger the action by `release: [created]` event as most people do.|
 | release_name           | **Optional**               | Alternative to `release_tag` for release target specification and binary push. The newest release by given `release_name` will be picked from all releases. Useful for e.g. untagged(draft) ones.|
+| release_repo           | **Optional**               | Repository where the build should be pushed to. By default the value for this is the repo from where the action is running. Useful if you use a different repository for your releases (private repo for code, public repo for releases).|
 | overwrite | **Optional** | Overwrite asset if it's already exist. `FALSE` by default. |
 | asset_name | **Optional** | Customize asset name if do not want to use the default format `${BINARY_NAME}-${RELEASE_TAG}-${GOOS}-${GOARCH}`. <br>Make sure set it correctly, especially for matrix usage that you have to append `-${{ matrix.goos }}-${{ matrix.goarch }}`. A valid example could be  `asset_name: binary-name-${{ matrix.goos }}-${{ matrix.goarch }}`. |
 | retry | **Optional** | How many times retrying if upload fails. `3` by default. |

--- a/action.yml
+++ b/action.yml
@@ -71,6 +71,10 @@ inputs:
     description: 'Upload binaries to specified release page that indicated by release name.'
     required: false
     default: ''
+  release_repo:
+    description: 'Repository to upload the binaries'
+    required: false
+    default: ''
   overwrite:
     description: "Overwrite asset if it's already exist."
     required: false
@@ -112,6 +116,7 @@ runs:
     - ${{ inputs.sha256sum }}
     - ${{ inputs.release_tag }}
     - ${{ inputs.release_name }}
+    - ${{ inputs.release_repo }}
     - ${{ inputs.overwrite }}
     - ${{ inputs.asset_name }}
     - ${{ inputs.retry }}

--- a/release.sh
+++ b/release.sh
@@ -22,6 +22,11 @@ if [ ! -z "${INPUT_ASSET_NAME}" ]; then
     RELEASE_ASSET_NAME=${INPUT_ASSET_NAME}
 fi
 
+RELEASE_REPO=${GITHUB_REPOSITORY}
+if [ ! -z "${INPUT_RELEASE_REPO}" ]; then
+  RELEASE_REPO=${INPUT_RELEASE_REPO}
+fi
+
 # prompt error if non-supported event
 if [ ${GITHUB_EVENT_NAME} == 'release' ]; then
     echo "Event: ${GITHUB_EVENT_NAME}"
@@ -139,19 +144,19 @@ if [ ${INPUT_OVERWRITE^^} == 'TRUE' ]; then
 fi
 
 # update binary and checksum
-github-assets-uploader -logtostderr -f ${RELEASE_ASSET_FILE} -mediatype ${MEDIA_TYPE} ${GITHUB_ASSETS_UPLOADR_EXTRA_OPTIONS} -repo ${GITHUB_REPOSITORY} -token ${INPUT_GITHUB_TOKEN} -tag=${RELEASE_TAG} -releasename=${RELEASE_NAME} -retry ${INPUT_RETRY}
+github-assets-uploader -logtostderr -f ${RELEASE_ASSET_FILE} -mediatype ${MEDIA_TYPE} ${GITHUB_ASSETS_UPLOADR_EXTRA_OPTIONS} -repo ${RELEASE_REPO} -token ${INPUT_GITHUB_TOKEN} -tag=${RELEASE_TAG} -releasename=${RELEASE_NAME} -retry ${INPUT_RETRY}
 if [ ${INPUT_MD5SUM^^} == 'TRUE' ]; then
 MD5_EXT='.md5'
 MD5_MEDIA_TYPE='text/plain'
 echo ${MD5_SUM} >${RELEASE_ASSET_FILE}${MD5_EXT}
-github-assets-uploader -logtostderr -f ${RELEASE_ASSET_FILE}${MD5_EXT} -mediatype ${MD5_MEDIA_TYPE} ${GITHUB_ASSETS_UPLOADR_EXTRA_OPTIONS} -repo ${GITHUB_REPOSITORY} -token ${INPUT_GITHUB_TOKEN} -tag=${RELEASE_TAG} -releasename=${RELEASE_NAME} -retry ${INPUT_RETRY}
+github-assets-uploader -logtostderr -f ${RELEASE_ASSET_FILE}${MD5_EXT} -mediatype ${MD5_MEDIA_TYPE} ${GITHUB_ASSETS_UPLOADR_EXTRA_OPTIONS} -repo ${RELEASE_REPO} -token ${INPUT_GITHUB_TOKEN} -tag=${RELEASE_TAG} -releasename=${RELEASE_NAME} -retry ${INPUT_RETRY}
 fi
 
 if [ ${INPUT_SHA256SUM^^} == 'TRUE' ]; then
 SHA256_EXT='.sha256'
 SHA256_MEDIA_TYPE='text/plain'
 echo ${SHA256_SUM} >${RELEASE_ASSET_FILE}${SHA256_EXT}
-github-assets-uploader -logtostderr -f ${RELEASE_ASSET_FILE}${SHA256_EXT} -mediatype ${SHA256_MEDIA_TYPE} ${GITHUB_ASSETS_UPLOADR_EXTRA_OPTIONS} -repo ${GITHUB_REPOSITORY} -token ${INPUT_GITHUB_TOKEN} -tag=${RELEASE_TAG} -releasename=${RELEASE_NAME} -retry ${INPUT_RETRY}
+github-assets-uploader -logtostderr -f ${RELEASE_ASSET_FILE}${SHA256_EXT} -mediatype ${SHA256_MEDIA_TYPE} ${GITHUB_ASSETS_UPLOADR_EXTRA_OPTIONS} -repo ${RELEASE_REPO} -token ${INPUT_GITHUB_TOKEN} -tag=${RELEASE_TAG} -releasename=${RELEASE_NAME} -retry ${INPUT_RETRY}
 fi
 
 # execute post-command if exist, e.g. upload to AWS s3 or aliyun OSS


### PR DESCRIPTION
This adds a feature where we can publish the release to an external repository, a good use case on this is when you have a private repository and wish to publish binaries to the public.

Added 2 test repos as an example:

- https://github.com/serafdev/go-release-action-test-private/blob/master/.github/workflows/release.yml
- https://github.com/serafdev/go-release-action-test-public/releases/tag/v0.0.1-alpha.1

Uploaded a dummy file (`go.mod`, can be found in the second link above) to test the supported flags from https://github.com/wangyoucao577/assets-uploader:

```bash
github-assets-uploader -logtostderr -f go.mod -mediatype application/gzip -repo serafdev/go-release-action-test-public -token REDACTED -tag=v0.0.1-alpha.1 -releasename=v0.0.1-alpha.1 -retry 3
```