### PR TITLE
Upgrade debian to buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM debian:stretch-slim
+FROM debian:buster-slim
 ARG UPX_VER
 ARG UPLOADER_VER
 ENV UPX_VER=${UPX_VER:-4.0.0}


### PR DESCRIPTION
LTS for stretch ended in June 2022, it this action container no longer builds in some pipelines.

Closes #120 