### PR TITLE
Add input of upload release switch and output of file related information

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ jobs:
         goarch: amd64
 ```
 
-### Parameters
+### Input Parameters
 
 | Parameter | **Mandatory**/**Optional** | Description |
 | --------- | -------- | ----------- |
@@ -80,6 +80,16 @@ jobs:
 | retry | **Optional** | How many times retrying if upload fails. `3` by default. |
 | post_command | **Optional** | Extra command that will be executed for teardown work. e.g. you can use it to upload artifacts to AWS s3 or aliyun OSS |
 | compress_assets | **Optional** | `auto` default will produce a `zip` file for Windows and `tar.gz` for others. `zip` will force the use of `zip`. `OFF` will disable packaging of assets. |
+| upload | **Optional** | Upload release or not upload. If you need to use subsequent workflow to process the file, you can choose not to upload the release. |
+
+### Output Parameters
+
+| Parameter | Description |
+| --------- | -------- |
+| release_asset_dir | Release file directory provided for use by other workflows. |
+| release_asset_name | Release file name without extension provided for use by other workflows. |
+| release_asset_file | Release file name with/without extension provided for use by other workflow. |
+
 
 ### Advanced Example
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ jobs:
 | Parameter | Description |
 | --------- | -------- |
 | release_asset_dir | Release file directory provided for use by other workflows. |
-| release_asset_name | Release file name without extension provided for use by other workflows. |
-| release_asset_file | Release file name with/without extension provided for use by other workflow. |
 
 
 ### Advanced Example

--- a/action.yml
+++ b/action.yml
@@ -107,12 +107,6 @@ inputs:
 outputs:
   release_asset_dir:
     description: 'Release file directory provided for use by other workflows'
-  release_asset_name:
-    description: 'Release file name without extension provided for use by other workflows'
-  release_asset_file:
-    description: 'Release file name with/without extension provided for use by other workflows'
-  release_asset_path:
-    description: 'Release file path provided for use by other workflows'
 
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -103,8 +103,6 @@ inputs:
 outputs:
   release_asset_dir:
     description: 'Release file directory provided for use by other workflows'
-  release_asset_archive_dir:
-    description: 'Release file archive directory provided for use by other workflows'
   release_asset_name:
     description: 'Release file name without extension provided for use by other workflows'
   release_asset_file:

--- a/action.yml
+++ b/action.yml
@@ -100,6 +100,18 @@ inputs:
     required: false
     default: 'TRUE'
 
+outputs:
+  release_asset_dir:
+    description: 'Release file directory provided for use by other workflows'
+  release_asset_archive_dir:
+    description: 'Release file archive directory provided for use by other workflows'
+  release_asset_name:
+    description: 'Release file name without extension provided for use by other workflows'
+  release_asset_file:
+    description: 'Release file name with extension provided for use by other workflows'
+  release_asset_path:
+    description: 'Release file path provided for use by other workflows'
+
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -99,6 +99,10 @@ inputs:
     description: 'Compress assets before uploading'
     required: false
     default: 'TRUE'
+  upload:
+    description: 'Upload release or not upload'
+    required: false
+    default: 'TRUE'
 
 outputs:
   release_asset_dir:
@@ -106,7 +110,7 @@ outputs:
   release_asset_name:
     description: 'Release file name without extension provided for use by other workflows'
   release_asset_file:
-    description: 'Release file name with extension provided for use by other workflows'
+    description: 'Release file name with/without extension provided for use by other workflows'
   release_asset_path:
     description: 'Release file path provided for use by other workflows'
 

--- a/release.sh
+++ b/release.sh
@@ -17,7 +17,11 @@ elif [ ! -z "${INPUT_RELEASE_NAME}" ]; then # prevent upload-asset by tag due to
   RELEASE_TAG=""
 fi
 
-RELEASE_NAME=${INPUT_RELEASE_NAME}
+if [ ! -z "${INPUT_RELEASE_NAME}" ]; then
+  RELEASE_NAME=${INPUT_RELEASE_NAME}
+else
+  RELEASE_NAME=$(jq -r '.release.name' ${GITHUB_EVENT_PATH})
+fi
 
 RELEASE_ASSET_NAME=${BINARY_NAME}-${RELEASE_TAG}-${INPUT_GOOS}-${INPUT_GOARCH}
 if [ ! -z "${INPUT_GOAMD64}" ]; then

--- a/release.sh
+++ b/release.sh
@@ -171,7 +171,7 @@ if [ ${INPUT_OVERWRITE^^} == 'TRUE' ]; then
     GITHUB_ASSETS_UPLOADR_EXTRA_OPTIONS="-overwrite"
 fi
 
-if [ ${GITHUB_EVENT_NAME} != 'workflow_dispatch' ]; then
+if [ ${INPUT_UPLOAD^^} == 'TRUE' ]; then
     # update binary and checksum
     github-assets-uploader -logtostderr -f ${RELEASE_ASSET_PATH} -mediatype ${MEDIA_TYPE} ${GITHUB_ASSETS_UPLOADR_EXTRA_OPTIONS} -repo ${RELEASE_REPO} -token ${INPUT_GITHUB_TOKEN} -tag=${RELEASE_TAG} -releasename=${RELEASE_NAME} -retry ${INPUT_RETRY}
     if [ ${INPUT_MD5SUM^^} == 'TRUE' ]; then

--- a/release.sh
+++ b/release.sh
@@ -143,21 +143,18 @@ if [ ${INPUT_COMPRESS_ASSETS^^} == "TRUE" ] || [ ${INPUT_COMPRESS_ASSETS^^} == "
     RELEASE_ASSET_EXT='.zip'
     MEDIA_TYPE='application/zip'
     RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}
-    RELEASE_ASSET_PATH=${RELEASE_ASSET_FILE}
-    ( shopt -s dotglob; zip -vr ${RELEASE_ASSET_PATH} ${BUILD_ARTIFACTS_FOLDER} )
+    ( shopt -s dotglob; zip -vr ${RELEASE_ASSET_FILE} ${BUILD_ARTIFACTS_FOLDER} )
   else
     RELEASE_ASSET_EXT='.tar.gz'
     MEDIA_TYPE='application/gzip'
     RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}
-    RELEASE_ASSET_PATH=${RELEASE_ASSET_FILE}
-    ( shopt -s dotglob; tar cvfz ${RELEASE_ASSET_PATH} ${BUILD_ARTIFACTS_FOLDER} )
+    ( shopt -s dotglob; tar cvfz ${RELEASE_ASSET_FILE} ${BUILD_ARTIFACTS_FOLDER} )
   fi
 elif [ ${INPUT_COMPRESS_ASSETS^^} == "OFF" ] || [ ${INPUT_COMPRESS_ASSETS^^} == "FALSE" ]; then
   RELEASE_ASSET_EXT=${EXT}
   MEDIA_TYPE="application/octet-stream"
   RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}
-  RELEASE_ASSET_PATH="${BUILD_ARTIFACTS_FOLDER}/${RELEASE_ASSET_FILE}"
-  cp ${BINARY_NAME}${EXT} ${RELEASE_ASSET_PATH}
+  cp ${BINARY_NAME}${EXT} "${BUILD_ARTIFACTS_FOLDER}/${RELEASE_ASSET_FILE}"
 else
   echo "Invalid value for INPUT_COMPRESS_ASSETS: ${INPUT_COMPRESS_ASSETS} . Acceptable values are AUTO,ZIP, or OFF."
   exit 1
@@ -193,15 +190,9 @@ ls -lha ${INPUT_PROJECT_PATH}
 
 # output path for use by other workflows (e.g.: actions/upload-artifact)
 echo "release_asset_dir=${RELEASE_ASSET_DIR}" >> "${GITHUB_OUTPUT}"
-echo "release_asset_name=${RELEASE_ASSET_NAME}" >> "${GITHUB_OUTPUT}"
-echo "release_asset_file=${RELEASE_ASSET_FILE}" >> "${GITHUB_OUTPUT}"
-echo "release_asset_path=${RELEASE_ASSET_PATH}" >> "${GITHUB_OUTPUT}"
 
 # execute post-command if exist, e.g. upload to AWS s3 or aliyun OSS
 if [ ! -z "${INPUT_POST_COMMAND}" ]; then
     INPUT_POST_COMMAND=${INPUT_POST_COMMAND/"{RELEASE_ASSET_DIR}"/${RELEASE_ASSET_DIR}}
-    INPUT_POST_COMMAND=${INPUT_POST_COMMAND/"{RELEASE_ASSET_NAME}"/${RELEASE_ASSET_NAME}}
-    INPUT_POST_COMMAND=${INPUT_POST_COMMAND/"{RELEASE_ASSET_FILE}"/${RELEASE_ASSET_FILE}}
-    INPUT_POST_COMMAND=${INPUT_POST_COMMAND/"{RELEASE_ASSET_PATH}"/${RELEASE_ASSET_PATH}}
     eval ${INPUT_POST_COMMAND}
 fi

--- a/release.sh
+++ b/release.sh
@@ -134,7 +134,8 @@ if [ ! -z "${INPUT_EXTRA_FILES}" ]; then
   cd ${INPUT_PROJECT_PATH}
 fi
 
-ls -lha ${BUILD_ARTIFACTS_FOLDER}
+cd ${BUILD_ARTIFACTS_FOLDER}
+ls -lha
 
 # INPUT_COMPRESS_ASSETS=='TRUE' is used for backwards compatability. `AUTO`, `ZIP`, `OFF` are the recommended values
 if [ ${INPUT_COMPRESS_ASSETS^^} == "TRUE" ] || [ ${INPUT_COMPRESS_ASSETS^^} == "AUTO" ] || [ ${INPUT_COMPRESS_ASSETS^^} == "ZIP" ]; then
@@ -143,18 +144,21 @@ if [ ${INPUT_COMPRESS_ASSETS^^} == "TRUE" ] || [ ${INPUT_COMPRESS_ASSETS^^} == "
     RELEASE_ASSET_EXT='.zip'
     MEDIA_TYPE='application/zip'
     RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}
-    ( shopt -s dotglob; zip -vr ${RELEASE_ASSET_FILE} ${BUILD_ARTIFACTS_FOLDER} )
+    RELEASE_ASSET_PATH="../${RELEASE_ASSET_FILE}"
+    ( shopt -s dotglob; zip -vr ${RELEASE_ASSET_PATH} * )
   else
     RELEASE_ASSET_EXT='.tar.gz'
     MEDIA_TYPE='application/gzip'
     RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}
-    ( shopt -s dotglob; tar cvfz ${RELEASE_ASSET_FILE} ${BUILD_ARTIFACTS_FOLDER} )
+    RELEASE_ASSET_PATH="../${RELEASE_ASSET_FILE}"
+    ( shopt -s dotglob; tar cvfz ${RELEASE_ASSET_PATH} * )
   fi
 elif [ ${INPUT_COMPRESS_ASSETS^^} == "OFF" ] || [ ${INPUT_COMPRESS_ASSETS^^} == "FALSE" ]; then
   RELEASE_ASSET_EXT=${EXT}
   MEDIA_TYPE="application/octet-stream"
   RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}
-  cp ${BINARY_NAME}${EXT} "${BUILD_ARTIFACTS_FOLDER}/${RELEASE_ASSET_FILE}"
+  RELEASE_ASSET_PATH=${RELEASE_ASSET_FILE}
+  cp ${BINARY_NAME}${EXT} ${RELEASE_ASSET_PATH}
 else
   echo "Invalid value for INPUT_COMPRESS_ASSETS: ${INPUT_COMPRESS_ASSETS} . Acceptable values are AUTO,ZIP, or OFF."
   exit 1
@@ -186,7 +190,7 @@ if [ ${INPUT_UPLOAD^^} == 'TRUE' ]; then
     fi
 fi
 
-ls -lha ${INPUT_PROJECT_PATH}
+ls -lha ../
 
 # output path for use by other workflows (e.g.: actions/upload-artifact)
 echo "release_asset_dir=${RELEASE_ASSET_DIR}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
通过添加文件名及文件路径至 GITHUB_OUTPUT, 可以使后续的 workflow 可以再次处理此文件.
例如: 用户可以不发布 Release, 而是手动触发 Action (workflow_dispatch 事件), 并通过 actions/upload-artifact 从 Artifacts 得到/发布一份 Nightly Build 用于测试.
https://github.com/lslqtz/go-testproject/actions/runs/7683774998

通过此实现也可以部分缓解 https://github.com/wangyoucao577/go-release-action/issues/53 问题, 如用户可以将文件放入缓存或其它地方, 并在其它不同 OS 的 job 下进行调用 (也许 macOS 下才能进行 Xcode 代码签名).

(标题名不太好, 几个问题, 1 是在 workflow_dispatch 事件下不触发 Release 上传是否合理, 2 是因为 actions/upload-artifact 本身会再次打包 zip, 因此若能传递文件夹会更好)

```
jobs:
  Release-Go-Binary:
    runs-on: 'ubuntu-latest'
    steps:
    - name: 'Checkout'
      uses: 'actions/checkout@v4'
    - name: 'Build'
      uses: 'lslqtz/go-release-action@master'
      id: release
      with:
        goos: 'linux'
        goarch: 'amd64'
        goversion: 1.19
        md5sum: false
        sha256sum: false
        binary_name: 'go-testproject'
    - name: 'Echo outputs'
      run: echo ${{join(steps.release.outputs.*, '\n')}}
    - name: 'Upload GitHub Artifact'
      uses: actions/upload-artifact@v4
      with:
        name: ${{ steps.release.outputs.release_asset_file }}
        path: ${{ steps.release.outputs.release_asset_path }}
```