### PR TITLE
Support pull_request event

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -36,10 +36,10 @@ if [ ! -z "${INPUT_RELEASE_REPO}" ]; then
 fi
 
 # prompt error if non-supported event
-if egrep -q 'release|push|workflow_dispatch|workflow_run|schedule' <<<"${GITHUB_EVENT_NAME}"; then
+if egrep -q 'release|push|pull_request|workflow_dispatch|workflow_run|schedule' <<<"${GITHUB_EVENT_NAME}"; then
   echo "Event: ${GITHUB_EVENT_NAME}"
 else
-  echo -e "Unsupport event: ${GITHUB_EVENT_NAME}! \nSupport: release | push | workflow_dispatch | workflow_run | schedule"
+  echo -e "Unsupport event: ${GITHUB_EVENT_NAME}! \nSupport: release | push | pull_request | workflow_dispatch | workflow_run | schedule"
   exit 1
 fi
 


### PR DESCRIPTION
配合所使用的 workflow, 于 https://github.com/Simple-Tracker/Action-Test/actions/runs/7855784009 进行了测试, 能够正常产生出 GitHub Artifacts.

关联此前的 Issue: https://github.com/wangyoucao577/go-release-action/issues/161

根据 Action 内给出的信息来看, 若通过此事件上传 Release, 则需要手动设置 release_tag 及 release_name, 与其它部分事件相似 (push/workflow_dispatch 等).