### PR TITLE
Fix ci warnging

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -35,7 +35,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     - name: Build & Publish to Github Container Registry
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ github.actor }}/${{ env.DOCKER_REPO_NAME }}
         username: ${{ github.actor }}
@@ -46,7 +46,7 @@ jobs:
         tags: "${{ env.IMAGE_TAG }}"
 
     - name: Build & Publish to DockerHub
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ github.repository }}
         username: ${{ github.actor }}

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -30,9 +30,9 @@ jobs:
     # Add support for more platforms with QEMU (optional)
     # https://github.com/docker/setup-qemu-action
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build & Publish to Github Container Registry
       uses: elgohr/Publish-Docker-Github-Action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     - name: Build & Publish to Github Container Registry
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ github.actor }}/${{ env.DOCKER_REPO_NAME }}
         username: ${{ github.actor }}
@@ -44,7 +44,7 @@ jobs:
         tags: "${{ env.IMAGE_TAG }}"
 
     - name: Build & Publish to DockerHub
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ github.repository }}
         username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,9 @@ jobs:
     # Add support for more platforms with QEMU (optional)
     # https://github.com/docker/setup-qemu-action
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build & Publish to Github Container Registry
       uses: elgohr/Publish-Docker-Github-Action@v5


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/