### PR TITLE
Support ldflags when building multi binaries

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -61,10 +61,7 @@ if [ ${INPUT_GOOS} == 'windows' ]; then
 fi
 
 # prefix for ldflags
-LDFLAGS_PREFIX=''
-if [ ! -z "${INPUT_LDFLAGS}" ]; then
-  LDFLAGS_PREFIX="-ldflags"
-fi
+LDFLAGS_PREFIX='-ldflags'
 
 # fulfill GOAMD64 option
 if [ ! -z "${INPUT_GOAMD64}" ]; then


### PR DESCRIPTION
Support ldflags when building multi binaries. This PR is a redo of https://github.com/wangyoucao577/go-release-action/pull/178 that also handles empty `ldflags`.
Because `INPUT_LDFLAGS` is always an argument to go build, even when empty, prefixing it with `LDFLAGS_PREFIX` will either use any flags or pass in an empty list of flags.
The [issue](https://github.com/wangyoucao577/go-release-action/actions/runs/12201486402/job/34040007059) with the previous PR is that the prefix was empty but the flags argument was being passed (due to double quotes):
> go build -v -tags v0.1-test-assets-20241206T152818 '' -o build-artifacts-1733498920 ./test/multi-binaries/cmd1 ./test/multi-binaries/cmd2

With this PR, the above call should look like:
> go build -v -tags v0.1-test-assets-20241206T152818 -ldflags '' -o build-artifacts-1733498920 ./test/multi-binaries/cmd1 ./test/multi-binaries/cmd2