### PR TITLE
Upgrade Debian base image and upx

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -5,7 +5,7 @@ on:
     branches-ignore:
       - '*-prebuilt'
       - 'release/**'
-    tags:        
+    tags:
       - 'v**'
     paths-ignore:
       - '**.md'
@@ -29,7 +29,7 @@ jobs:
           - goarch: arm
             goos: darwin
           - goarch: arm
-            goos: windows   
+            goos: windows
         include:
           - goos: linux
             goarch: amd64
@@ -44,10 +44,10 @@ jobs:
             goarch: amd64
             goamd64: v3
           - goos: darwin
-            goarch: amd64            
+            goarch: amd64
           - goos: linux
             goarch: arm
-            goarm: "7"            
+            goarm: "7"
     steps:
     # - name: Wait release docker build for release branches
     #   if: contains(github.ref, 'release')
@@ -70,7 +70,7 @@ jobs:
         project_path: ./test/
         binary_name: testmain
         pre_command: go mod init localtest
-        executable_compression: upx -v
+        executable_compression: upx -v --force-macos
         build_flags: -v
         ldflags: -X "main.buildTime=${{ env.BUILD_TIME }}" -X main.gitCommit=${{ github.sha }} -X main.gitRef=${{ github.ref }}
         md5sum: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-
-FROM debian:buster-slim
+FROM debian:trixie-slim
 ARG UPX_VER
 ARG UPLOADER_VER
-ENV UPX_VER=${UPX_VER:-4.0.0}
+ENV UPX_VER=${UPX_VER:-5.0.2}
 ENV UPLOADER_VER=${UPLOADER_VER:-v0.13.0}
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
@@ -17,7 +16,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteract
   && rm -rf /var/lib/apt/lists/*
 
 # install latest upx 3.96 by wget instead of `apt install upx-ucl`(only 3.95)
-RUN export arch=$(dpkg --print-architecture) && wget --no-check-certificate --progress=dot:mega https://github.com/upx/upx/releases/download/v${UPX_VER}/upx-${UPX_VER}-${arch}_linux.tar.xz && \
+RUN export arch=$(dpkg --print-architecture) && \
+  wget --progress=dot:mega https://github.com/upx/upx/releases/download/v${UPX_VER}/upx-${UPX_VER}-${arch}_linux.tar.xz && \
   tar -Jxf upx-${UPX_VER}-${arch}_linux.tar.xz && \
   mv upx-${UPX_VER}-${arch}_linux /usr/local/ && \
   ln -s /usr/local/upx-${UPX_VER}-${arch}_linux/upx /usr/local/bin/upx && \
@@ -25,7 +25,8 @@ RUN export arch=$(dpkg --print-architecture) && wget --no-check-certificate --pr
   upx --version
 
 # github-assets-uploader to provide robust github assets upload
-RUN export arch=$(dpkg --print-architecture) && wget --no-check-certificate --progress=dot:mega https://github.com/wangyoucao577/assets-uploader/releases/download/${UPLOADER_VER}/github-assets-uploader-${UPLOADER_VER}-linux-${arch}.tar.gz -O github-assets-uploader.tar.gz && \
+RUN export arch=$(dpkg --print-architecture) && \
+  wget --progress=dot:mega https://github.com/wangyoucao577/assets-uploader/releases/download/${UPLOADER_VER}/github-assets-uploader-${UPLOADER_VER}-linux-${arch}.tar.gz -O github-assets-uploader.tar.gz && \
   tar -zxf github-assets-uploader.tar.gz && \
   mv github-assets-uploader /usr/sbin/ && \
   rm -f github-assets-uploader.tar.gz && \


### PR DESCRIPTION
The Docker build was failing with the previous Debian Buster base image. This updates the Dockerfile to use `debian:trixie-slim` to resolve the build issues.

Additionally, `upx` is upgraded to version 5.0.2. This version requires the `--force-macos` flag for macOS executables, which has been updated in the autotest workflow.

This also removes unnecessary `--no-check-certificate` flags from wget commands and cleans up trailing whitespace.