### PR TITLE
feat: add tar option for assets compression

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -182,7 +182,7 @@ jobs:
       matrix:
         goos: [linux, windows, darwin]
         goarch: [amd64]
-        compress_assets: ['auto', 'true', 'zip', 'off', 'false']
+        compress_assets: ['auto', 'true', 'zip', 'tar', 'off', 'false']
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ jobs:
 | asset_name | **Optional** | Customize asset name if do not want to use the default format `${BINARY_NAME}-${RELEASE_TAG}-${GOOS}-${GOARCH}`. <br>Make sure set it correctly, especially for matrix usage that you have to append `-${{ matrix.goos }}-${{ matrix.goarch }}`. A valid example could be  `asset_name: binary-name-${{ matrix.goos }}-${{ matrix.goarch }}`. |
 | retry | **Optional** | How many times retrying if upload fails. `3` by default. |
 | post_command | **Optional** | Extra command that will be executed for teardown work. e.g. you can use it to upload artifacts to AWS s3 or aliyun OSS |
-| compress_assets | **Optional** | `auto` default will produce a `zip` file for Windows and `tar.gz` for others. `zip` will force the use of `zip`. `OFF` will disable packaging of assets. |
+| compress_assets | **Optional** | `auto` default will produce a `zip` file for Windows and `tar.gz` for others. `zip` will force the use of `zip`. `tar` will force the use of `tar`. `OFF` will disable packaging of assets. |
 | upload | **Optional** | Upload release assets or not. It'll be useful if you'd like to use subsequent workflow to process the file, such as **signing it on macos**, and so on. |
 
 ### Output Parameters

--- a/release.sh
+++ b/release.sh
@@ -160,10 +160,10 @@ fi
 cd ${BUILD_ARTIFACTS_FOLDER}
 ls -lha
 
-# INPUT_COMPRESS_ASSETS=='TRUE' is used for backwards compatability. `AUTO`, `ZIP`, `OFF` are the recommended values
-if [ ${INPUT_COMPRESS_ASSETS^^} == "TRUE" ] || [ ${INPUT_COMPRESS_ASSETS^^} == "AUTO" ] || [ ${INPUT_COMPRESS_ASSETS^^} == "ZIP" ]; then
+# INPUT_COMPRESS_ASSETS=='TRUE' is used for backwards compatability. `AUTO`, `ZIP`, `TAR`, `OFF` are the recommended values
+if [ ${INPUT_COMPRESS_ASSETS^^} == "TRUE" ] || [ ${INPUT_COMPRESS_ASSETS^^} == "AUTO" ] || [ ${INPUT_COMPRESS_ASSETS^^} == "ZIP" ] || [ ${INPUT_COMPRESS_ASSETS^^} == "TAR" ]; then
   # compress and package binary, then calculate checksum
-  if [ ${INPUT_GOOS} == 'windows' ] || [ ${INPUT_COMPRESS_ASSETS^^} == "ZIP" ]; then
+  if ([ ${INPUT_GOOS} == 'windows' ] && [ ${INPUT_COMPRESS_ASSETS^^} != "TAR" ]) || [ ${INPUT_COMPRESS_ASSETS^^} == "ZIP" ]; then
     RELEASE_ASSET_EXT='.zip'
     MEDIA_TYPE='application/zip'
     RELEASE_ASSET_FILE=${RELEASE_ASSET_NAME}${RELEASE_ASSET_EXT}


### PR DESCRIPTION
If `compress_assets: tar` is used this will also produce `tar.gz` files on windows.

Resolves #181 